### PR TITLE
Account for ALPM_DB_VERSION in package count

### DIFF
--- a/paleofetch.c
+++ b/paleofetch.c
@@ -140,7 +140,7 @@ char *get_packages() {
     while((entry = readdir(dirp)) != NULL) {
         if(entry->d_type == DT_DIR) num_packages++;
     }
-    num_packages -= 2; // accounting for . and ..
+    num_packages -= 3; // accounting for ., .., and ALPM_DB_VERSION
 
     status = closedir(dirp);
 


### PR DESCRIPTION
Tallying the number of entries in `/var/lib/pacman/local` is a pretty surefire way to get the package count, but there's a stray file hiding in there that we want to ignore.