### PR TITLE
Make get_shell() handle shells that aren't in /bin

### DIFF
--- a/paleofetch.c
+++ b/paleofetch.c
@@ -152,7 +152,7 @@ char *get_packages() {
 
 char *get_shell() {
     char *shell = malloc(BUF_SIZE);
-    sscanf(getenv("SHELL"), "/bin/%s", shell);
+    strcpy(shell, strrchr(getenv("SHELL"), '/') + 1);
     return shell;
 }
 


### PR DESCRIPTION
`get_shell()` currently assumes the relevant environment variable will be of the form `/bin/%s`, but this isn't always the case. This patch instead assumes that everything after the last `/` is the name of the user's shell.