### PR TITLE
Let getline() handle buffer allocation in get_memory()

### DIFF
--- a/paleofetch.c
+++ b/paleofetch.c
@@ -187,7 +187,7 @@ char *get_memory() {
     }
 
     /* We parse through all lines of meminfo and scan for the information we need */
-    char *line = malloc(BUF_SIZE);
+    char *line = NULL; // allocation handled automatically by getline()
     size_t len; /* unused */
 
     /* parse until EOF */


### PR DESCRIPTION
This is a little nitpicky, but paleofetch is Valgrind-clean modulo this line. It is the right way to use `getline()`, though, which expects a null buffer that it can grow and shrink as necessary.