### PR TITLE
Add product version to host

### DIFF
--- a/paleofetch.c
+++ b/paleofetch.c
@@ -42,6 +42,11 @@ struct sysinfo my_sysinfo;
 int title_length;
 int status;
 
+void remove_newline(char *s) {
+    while (*(++s) != '\n');
+    *s = '\0';
+}
+
 void halt_and_catch_fire(const char *message) {
     if(status != 0) {
         printf("%s\n", message);
@@ -155,10 +160,8 @@ char *get_host() {
     fread(version, 1, BUF_SIZE, product_version);
     fclose(product_version);
 
-    // trim trailing newline
-    char *s = host;
-    while(*(++s) != '\n') ;
-    *s = '\0';
+    remove_newline(host);
+    remove_newline(version);
 
     strcat(host, " ");
     strcat(host, version);

--- a/paleofetch.c
+++ b/paleofetch.c
@@ -143,10 +143,25 @@ char *get_host() {
     fread(host, 1, BUF_SIZE, product_name);
     fclose(product_name);
 
+    FILE *product_version = fopen("/sys/devices/virtual/dmi/id/product_version", "r");
+
+    if(product_version == NULL) {
+        status = -1;
+        halt_and_catch_fire("unable to open product version file");
+    }
+
+    char version[BUF_SIZE];
+
+    fread(version, 1, BUF_SIZE, product_version);
+    fclose(product_version);
+
     // trim trailing newline
     char *s = host;
     while(*(++s) != '\n') ;
     *s = '\0';
+
+    strcat(host, " ");
+    strcat(host, version);
 
     return host;
 }


### PR DESCRIPTION
On Lenovo ThinkPads (T60 and X220 tested) product_name only contains the serial number. The actual model is accessible through product_version.
Concatenate product_name with product_version to get full host output like in neofetch.