### PR TITLE
Fix OS detection on Debian 10 and other distros

### DIFF
--- a/paleofetch.c
+++ b/paleofetch.c
@@ -104,14 +104,20 @@ char *get_bar() {
 
 char *get_os() {
     char *os = malloc(BUF_SIZE),
-         *name = malloc(BUF_SIZE);
+         *name = malloc(BUF_SIZE),
+         *line = NULL;
+    size_t len;
     FILE *os_release = fopen("/etc/os-release", "r");
     if(os_release == NULL) {
         status = -1;
         halt_and_catch_fire("unable to open /etc/os-release");
     }
 
-    fscanf(os_release, "NAME=\"%[^\"]+", name);
+    while (getline(&line, &len, os_release) != -1) {
+        if (sscanf(line, "NAME=\"%[^\"]+", name) > 0) break;
+    }
+
+    free(line);
     fclose(os_release);
     snprintf(os, BUF_SIZE, "%s %s", name, uname_info.machine);
     free(name);


### PR DESCRIPTION
Debian has the NAME value in /etc/os-release on the second line.
Parse through /etc/os-release line for line until NAME is found.

Before:
![broken_debian](https://user-images.githubusercontent.com/50058606/80151083-c17f2280-85b9-11ea-9119-7e6ec91fb8e7.png)

After:
![nonbroken_debian](https://user-images.githubusercontent.com/50058606/80151099-c7750380-85b9-11ea-9946-8787cd847a60.png)
