### PR TITLE
Handle cache misses gracefully

### DIFF
--- a/paleofetch.c
+++ b/paleofetch.c
@@ -19,6 +19,14 @@
 #define BUF_SIZE 150
 #define REMOVE_CONST_STRING(A, B) remove_substring((A), (B), sizeof(B) - 1)
 
+#define halt_and_catch_fire(fmt, ...) \
+    do { \
+        if(status != 0) { \
+            fprintf(stderr, "paleofetch: " fmt "\n", ##__VA_ARGS__); \
+            exit(status); \
+        } \
+    } while(0)
+
 struct conf {
     char *label, *(*function)();
     bool cached;
@@ -29,12 +37,6 @@ struct utsname uname_info;
 struct sysinfo my_sysinfo;
 int title_length;
 int status;
-
-#define halt_and_catch_fire(fmt, ...) \
-    if(status != 0) { \
-        fprintf(stderr, "paleofetch: " fmt "\n", ##__VA_ARGS__); \
-        exit(status); \
-    }
 
 /*
  * Replaces the first newline character with null terminator


### PR DESCRIPTION
If the user changes their config to cache a new value, recompiles, and then runs paleofetch without `--recache`, we segfault when we go looking for the new key in the now-stale cache.

This patch fixes that by checking whether `strstr()` found something and bails if it didn't, guiding the user in the direction of the fix.

Because this seemed like a good use case for a formatted exit message, `halt_and_catch_fire()` was refactored to behave like `fprintf(stderr, ...)`.

Token-pasting `__VA_ARGS__` is a widely adopted extension (at least, GCC and Clang have supported it for ages) that I made use of so that I didn't have to touch any other calls to `halt_and_catch_fire()`. Without the `##`, they'd leave a trailing comma in the expansion and result in invalid syntax.