### PR TITLE
Make substring removing for CPU and GPU configurable

### DIFF
--- a/config.h
+++ b/config.h
@@ -23,3 +23,22 @@
     { "",             get_colors1,    false }, \
     { "",             get_colors2,    false }, \
 };
+
+#define CPU_REMOVE \
+{ \
+   /* string   length */ \
+   { "(R)",         3 }, \
+   { "(TM)",        4 }, \
+   { "Dual-Core",   9 }, \
+   { "Quad-Core",   9 }, \
+   { "Six-Core",    8 }, \
+   { "Eight-Core", 10 }, \
+   { "Core",        4 }, \
+   { "CPU",         3 }, \
+};
+
+#define GPU_REMOVE \
+{ \
+   /* string    length */ \
+   { "Corporation", 11 }, \
+};

--- a/config.h
+++ b/config.h
@@ -26,19 +26,17 @@
 
 #define CPU_REMOVE \
 { \
-   /* string   length */ \
-   { "(R)",         3 }, \
-   { "(TM)",        4 }, \
-   { "Dual-Core",   9 }, \
-   { "Quad-Core",   9 }, \
-   { "Six-Core",    8 }, \
-   { "Eight-Core", 10 }, \
-   { "Core",        4 }, \
-   { "CPU",         3 }, \
+   REMOVE("(R)"), \
+   REMOVE("(TM)"), \
+   REMOVE("Dual-Core"), \
+   REMOVE("Quad-Core"), \
+   REMOVE("Six-Core"), \
+   REMOVE("Eight-Core"), \
+   REMOVE("Core"), \
+   REMOVE("CPU"), \
 };
 
 #define GPU_REMOVE \
 { \
-   /* string    length */ \
-   { "Corporation", 11 }, \
+    REMOVE("Corporation"), \
 };

--- a/paleofetch.c
+++ b/paleofetch.c
@@ -16,12 +16,21 @@
 #include "config.h"
 
 #define BUF_SIZE 150
+#define COUNT(x) (int)(sizeof x / sizeof *x)
 #define REMOVE_CONST_STRING(A, B) remove_substring((A), (B), sizeof(B) - 1)
 
 struct conf {
     char *label, *(*function)();
     bool cached;
 } config[] = CONFIG;
+
+typedef struct {
+    char *substring;
+    size_t length;
+} STRING_REMOVE;
+
+STRING_REMOVE cpu_remove[] = CPU_REMOVE;
+STRING_REMOVE gpu_remove[] = GPU_REMOVE;
 
 Display *display;
 struct utsname uname_info;
@@ -356,14 +365,9 @@ char *get_cpu() {
     fclose(cpufreq);
 
     /* remove unneeded information */
-    REMOVE_CONST_STRING(cpu_model, "(R)");
-    REMOVE_CONST_STRING(cpu_model, "(TM)");
-    REMOVE_CONST_STRING(cpu_model, "Dual-Core");
-    REMOVE_CONST_STRING(cpu_model, "Quad-Core");
-    REMOVE_CONST_STRING(cpu_model, "Six-Core");
-    REMOVE_CONST_STRING(cpu_model, "Eight-Core");
-    REMOVE_CONST_STRING(cpu_model, "Core");
-    REMOVE_CONST_STRING(cpu_model, "CPU");
+    for (int i = 0; i < COUNT(cpu_remove); ++i) {
+        remove_substring(cpu_model, cpu_remove[i].substring, cpu_remove[i].length);
+    }
 
     char *cpu = malloc(BUF_SIZE);
     snprintf(cpu, BUF_SIZE, "%s (%d) @ %.1fGHz", cpu_model, num_cores, freq);
@@ -406,8 +410,14 @@ char *find_gpu(int index) {
     if (found == false) *gpu = '\0'; // empty string, so it will not be printed
 
     pci_cleanup(pacc);
-    REMOVE_CONST_STRING(gpu, "Corporation");
+
+    /* remove unneeded information */
+    for (int i = 0; i < COUNT(gpu_remove); ++i) {
+        remove_substring(gpu, gpu_remove[i].substring, gpu_remove[i].length);
+    }
+
     truncate_spaces(gpu);
+
     return gpu;
 }
 
@@ -562,7 +572,6 @@ int main(int argc, char *argv[]) {
         fclose(cache_file); // We just need the first (and only) line.
     }
 
-#define COUNT(x) (int)(sizeof x / sizeof *x)
     int offset = 0;
 
     for (int i = 0; i < COUNT(LOGO); i++) {

--- a/paleofetch.c
+++ b/paleofetch.c
@@ -17,7 +17,6 @@
 
 #define BUF_SIZE 150
 #define COUNT(x) (int)(sizeof x / sizeof *x)
-#define REMOVE_CONST_STRING(A, B) remove_substring((A), (B), sizeof(B) - 1)
 
 struct conf {
     char *label, *(*function)();

--- a/paleofetch.h
+++ b/paleofetch.h
@@ -20,3 +20,4 @@ char *get_title(),
      *spacer();
 
 #define SPACER {"", spacer, false},
+#define REMOVE(A) { (A), sizeof(A) }


### PR DESCRIPTION
This adds a configurable way to remove substrings from CPU and GPU model names.
I was not able to make it work with the new REPLACE_CONST_STRING macro. It would be nice if one could omit the substring length in the config, maybe somebody has a neat idea for this.