### PR TITLE
Fix wrong string length in REMOVE macro

### DIFF
--- a/paleofetch.h
+++ b/paleofetch.h
@@ -20,4 +20,4 @@ char *get_title(),
      *spacer();
 
 #define SPACER {"", spacer, false},
-#define REMOVE(A) { (A), sizeof(A) }
+#define REMOVE(A) { (A), sizeof(A) - 1}


### PR DESCRIPTION
The sizeof operator returns number of chars + \0, but remove_string() expects only number of characters