### PR TITLE
~💥 disabled line wrap to keep logo intact on small terminal

### DIFF
--- a/paleofetch.c
+++ b/paleofetch.c
@@ -222,7 +222,7 @@ static char *get_uptime() {
     char *uptime = malloc(BUF_SIZE);
     for (int i = 0; i < 3; ++i ) {
         if ((n = seconds / units[i].secs) || i == 2) /* always print minutes */
-            len += snprintf(uptime + len, BUF_SIZE - len, 
+            len += snprintf(uptime + len, BUF_SIZE - len,
                             "%d %s%s, ", n, units[i].name, n != 1 ? "s": "");
         seconds %= units[i].secs;
     }
@@ -308,10 +308,10 @@ static char *get_shell() {
 static char *get_resolution() {
     int screen, width, height;
     char *resolution = malloc(BUF_SIZE);
-    
+
     if (display != NULL) {
         screen = DefaultScreen(display);
-    
+
         width = DisplayWidth(display, screen);
         height = DisplayHeight(display, screen);
 
@@ -324,7 +324,7 @@ static char *get_resolution() {
         FILE *modes;
         char *line = NULL;
         size_t len;
-        
+
         /* preload resolution with empty string, in case we cant find a resolution through parsing */
         strncpy(resolution, "", BUF_SIZE);
 
@@ -354,7 +354,7 @@ static char *get_resolution() {
                 }
             }
         }
-        
+
         closedir(dir);
     }
 
@@ -366,10 +366,10 @@ static char *get_terminal() {
     char *terminal = malloc(BUF_SIZE);
 
     /* check if xserver is running or if we are running in a straight tty */
-    if (display != NULL) {   
+    if (display != NULL) {
 
     unsigned long _, // not unused, but we don't need the results
-                  window = RootWindow(display, XDefaultScreen(display));    
+                  window = RootWindow(display, XDefaultScreen(display));
         Atom a,
              active = XInternAtom(display, "_NET_ACTIVE_WINDOW", True),
              class = XInternAtom(display, "WM_CLASS", True);
@@ -690,6 +690,9 @@ int main(int argc, char *argv[]) {
     FILE *cache_file;
     int read_cache;
 
+    /* Disable line wrap */
+    printf("\e[?7l");
+
     status = uname(&uname_info);
     halt_and_catch_fire("uname failed");
     status = sysinfo(&my_sysinfo);
@@ -748,9 +751,12 @@ int main(int argc, char *argv[]) {
 
     free(cache);
     free(cache_data);
-    if(display != NULL) { 
+    if(display != NULL) {
         XCloseDisplay(display);
     }
+
+    /* Re-enable line wrap */
+    printf("\e[?7h");
 
     return 0;
 }


### PR DESCRIPTION
added printf statements at the top of main to disable line wraps during the entire run to keep logo intact on small terminal or when terminal is resized, and disabled line wrap before exit.